### PR TITLE
Revert "changed to alpine 15 image"

### DIFF
--- a/k8s/postgresql.yaml
+++ b/k8s/postgresql.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:15-alpine
+          image: postgres:alpine
           ports:
             - containerPort: 5432
               protocol: TCP
@@ -28,48 +28,13 @@ spec:
                 secretKeyRef:
                   name: postgres-creds
                   key: password
-            - name: POSTGRES_USER
-              valueFrom:
-                configMapKeyRef:
-                  name: postgres-config
-                  key: postgres_user
-            - name: POSTGRES_DB
-              valueFrom:
-                configMapKeyRef:
-                  name: postgres-config
-                  key: postgres_db                                                         
           volumeMounts:
           - name: postgres-storage
-            mountPath: /var/lib/postgresql
-          resources:
-            limits:
-              cpu: "0.50"
-              memory: "128Mi"
-            requests:
-              cpu: "0.25"
-              memory: "64Mi"            
+            mountPath: /var/lib/postgresql/data
 
       volumes:
       - name: postgres-storage
-        persistentVolumeClaim: 
-          claimName: postgres-pvc  
-
-        #emptyDir: {}
-
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: postgres-pvc
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
-  # storageClassName: default
-
-
+        emptyDir: {}
 
 
 ---
@@ -86,24 +51,3 @@ spec:
   ports:
     - port: 5432
       targetPort: 5432
-
----
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: postgres-config
-data:
-  postgres_user: postgres
-  postgres_db: products 
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: postgres-creds
-data:
-  password: cGdzM2NyM3Q=
-  database_uri: |
-      cG9zdGdyZXNxbCtwc3ljb3BnOi8vcG9zdGdyZXM6cGdzM2NyM3RAcG9zdGdyZXM6NTQzMi9wZXRz
-      dG9yZQ==


### PR DESCRIPTION
Reverts CSCI-GA-2820-FA23-003/products#65
This postgress yaml should go under tekton folder and the K8s shoould be as before to properly deploy locally.